### PR TITLE
Added filter_matched on drop with test for add_field

### DIFF
--- a/lib/logstash/filters/drop.rb
+++ b/lib/logstash/filters/drop.rb
@@ -40,5 +40,6 @@ class LogStash::Filters::Drop < LogStash::Filters::Base
   public
   def filter(event)
     event.cancel if (@percentage == 100 || rand < (@percentage / 100.0))
+    filter_matched(event)
   end # def filter
 end # class LogStash::Filters::Drop

--- a/spec/filters/drop_spec.rb
+++ b/spec/filters/drop_spec.rb
@@ -16,16 +16,30 @@ describe LogStash::Filters::Drop do
       subject.filter(event)
       expect(event).to be_cancelled
     end
-
+  
     context "when using percentage" do
-      let(:config) { { "percentage" => 0 }}
+      let(:config) { { "percentage" => 100 }}
 
       it "drops the event" do
         subject.register
         subject.filter(event)
-        expect(event).not_to be_cancelled
+        expect(event).to be_cancelled
       end
-
     end
+
+  end
+
+  describe "keeps the event" do
+
+    context "when using percentage with added field" do
+      let(:config) { { "percentage" => 0, "add_field" => { "field1" => "pass" } }}
+
+      it "keeps the event" do
+        subject.register
+        subject.filter(event)
+        expect(event.get("field1")).to eq("pass")
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Fixed bug with Filter_matched not being called on non-dropped events and included test on using add_field with non-dropped events. In reference to the following issues ["apply filter_matched on non dropped events #4"](https://github.com/logstash-plugins/logstash-filter-drop/issues/4), ["Add/remove tags and fields in docs are misleading #5"](https://github.com/logstash-plugins/logstash-filter-drop/issues/5)
